### PR TITLE
Various fixes.

### DIFF
--- a/export_mdl/classes/War3AnimationCurve.py
+++ b/export_mdl/classes/War3AnimationCurve.py
@@ -292,7 +292,48 @@ class War3AnimationCurve:
                     writer.write("\tOutTan %s" % (line % tuple(f2s(rnd(x)) for x in hr)))
            
         writer.end_scope()
+      
+    def write_mdl_one_channel(self, name, writer, model, index, base_value):
+        # This is used for outputting the particle emitter width/length animations.
+        # It's mostly a copy paste of 'write_mdl' and can be obviously "improved".
         
+        f2ms = 1000 / bpy.context.scene.render.fps
+    
+        writer.begin_scope(name, "%d" % len(self.keyframes))
+        if self.type != 'EventTrack':
+            writer.write(self.interpolation)
+        if self.global_sequence > 0:
+            writer.write("GlobalSeqId %d" % model.global_seqs.index(self.global_sequence))
+            
+        for frame in sorted(self.keyframes.keys()):
+            n = len(self.keyframes[frame])
+            line = "%s"
+            if self.type == 'EventTrack':
+                writer.write("%d" % (frame * f2ms))
+            else:
+                keyframe = self.keyframes[frame]
+                
+                if self.type == 'Rotation':
+                    keyframe = keyframe[1:] + keyframe[:1] # MDL quaternions must be on the form XYZW
+                
+                value = line % f2s(rnd(keyframe[index]*base_value))
+                writer.write("%d: %s" % (frame * f2ms, value))
+
+                    
+                if self.interpolation == 'Bezier':
+                    hl = self.handles_left[frame]
+                    hr = self.handles_right[frame]
+                    
+                    if self.type == 'Rotation':
+                        hl = hl[1:]+hl[:1]
+                        hr = hr[1:]+hr[:1]
+                
+                    writer.write("\tInTan %s" % (line % f2s(rnd(hl[index] * base_value))))
+                    writer.write("\tOutTan %s" % (line % f2s(rnd(hr[index] * base_value))))
+           
+        writer.end_scope()
+        
+
     def write_mdx(self, model, writer):
         pass
         

--- a/export_mdl/classes/War3ParticleSystem.py
+++ b/export_mdl/classes/War3ParticleSystem.py
@@ -49,7 +49,7 @@ class War3ParticleSystem(War3Object):
         self.tail_length = 0
         self.time = 0.5
         self.priority_plane = 0
-        self.ribbon_material_id = 0
+        self.ribbon_material = 0
         self.ribbon_color = (1.0, 1.0, 1.0)
         self.texture_id = 0
         self.model_path = ""
@@ -116,7 +116,7 @@ class War3ParticleSystem(War3Object):
         self.tail_length = emitter.tail_length
         self.time = emitter.time
         self.priority_plane = emitter.priority_plane
-        self.ribbon_material_id = emitter.ribbon_material_id
+        self.ribbon_material = emitter.ribbon_material
         self.ribbon_color = emitter.ribbon_color
         self.model_path = emitter.model_path
         self.head_life_start = emitter.head_life_start

--- a/export_mdl/classes/War3TextureAnim.py
+++ b/export_mdl/classes/War3TextureAnim.py
@@ -44,9 +44,9 @@ class War3TextureAnim:
         anim = War3TextureAnim()
         if anim_data.action:
             if len(uv_node.inputs) > 1: # 2.81 Mapping Node
-                anim.translation = War3AnimationCurve.get(anim_data, 'nodes["%s"].inputs["Location"].default_value' % uv_node.name, 3, sequences)
-                anim.rotation = War3AnimationCurve.get(anim_data, 'nodes["%s"].inputs["Rotation"].default_value' % uv_node.name, 3, sequences)
-                anim.scale = War3AnimationCurve.get(anim_data, 'nodes["%s"].inputs["Scale"].default_value' % uv_node.name, 3, sequences)
+                anim.translation = War3AnimationCurve.get(anim_data, 'nodes["%s"].inputs[1].default_value' % uv_node.name, 3, sequences)
+                anim.rotation = War3AnimationCurve.get(anim_data, 'nodes["%s"].inputs[2].default_value' % uv_node.name, 3, sequences)
+                anim.scale = War3AnimationCurve.get(anim_data, 'nodes["%s"].inputs[3].default_value' % uv_node.name, 3, sequences)
             else:
                 anim.translation = War3AnimationCurve.get(anim_data, 'nodes["%s"].translation' % uv_node.name, 3, sequences)
                 anim.rotation = War3AnimationCurve.get(anim_data, 'nodes["%s"].rotation' % uv_node.name, 3, sequences)

--- a/export_mdl/export_mdl.py
+++ b/export_mdl/export_mdl.py
@@ -204,7 +204,7 @@ def save(operator, context, settings, filepath="", mdl_version=800):
                 uv_anim.rotation.write_mdl("Rotation", writer, model)
                 
             if uv_anim.scale is not None:
-                uv_anim.scaling.write_mdl("Scaling", writer, model)
+                uv_anim.scale.write_mdl("Scaling", writer, model)
                 
             writer.end_scope()
         writer.end_scope()
@@ -540,14 +540,14 @@ def save(operator, context, settings, filepath="", mdl_version=800):
         else:
             writer.write("static EmissionRate %s" % f2s(rnd(psys.emission_rate)))
             
-        # FIXME FIXME FIXME FIXME FIXME: Separate X and Y channels! New animation class won't handle this. 
-        if psys.scale_anim is not None and ('scale', 1) in psys.scale_anim.keys():
-            psys.scale_anim.write_mdl("Width", writer, model)
+        # @TODO: Verify if X/Y swapping is actually needed.
+        if psys.scale_anim is not None:
+            psys.scale_anim.write_mdl_one_channel("Width", writer, model, 1, psys.dimensions[1])
         else:
             writer.write("static Width %s" % f2s(rnd(psys.dimensions[1])))
             
-        if psys.scale_anim is not None and ('scale', 0) in psys.scale_anim.keys():
-            psys.scale_anim.write_mdl("Length", writer, model)
+        if psys.scale_anim is not None:
+            psys.scale_anim.write_mdl_one_channel("Length", writer, model, 0, psys.dimensions[0])
         else:
             writer.write("static Length %s" % f2s(rnd(psys.dimensions[0])))
             
@@ -576,7 +576,7 @@ def save(operator, context, settings, filepath="", mdl_version=800):
         writer.write("DecayUVAnim {%d, %d, %d}" % (psys.head_decay_start, psys.head_decay_end, psys.head_decay_repeat))
         writer.write("TailUVAnim {%d, %d, %d}" % (psys.tail_life_start, psys.tail_life_end, psys.tail_life_repeat))
         writer.write("TailDecayUVAnim {%d, %d, %d}" % (psys.tail_decay_start, psys.tail_decay_end, psys.tail_decay_repeat))
-        writer.write("TextureID %d" % model.textures[psys.texture_id])
+        writer.write("TextureID %d" % psys.texture_id)
         if psys.priority_plane != 0:
             writer.write("PriorityPlane %d" % psys.priority_plane)
         writer.end_scope()

--- a/export_mdl/ui/WAR3_PT_particle_editor_panel.py
+++ b/export_mdl/ui/WAR3_PT_particle_editor_panel.py
@@ -72,6 +72,7 @@ class WAR3_PT_particle_editor_panel(Panel):
             row.prop(psys, "texture_path", text="")
             
             layout.prop(psys, "filter_mode")
+            layout.prop(psys, "priority_plane")
             
             layout.separator()
             


### PR DESCRIPTION
- Fixed particle emitters exporting.
- Fixed texture animation exporting.
- Added the priority plane field for emitters on the Blender's UI.
- Empty objects starting with "bone_" or "helper_" are now recognized as potential bones or helpers.
- Fixed particle emitters' width and length animation exporting.
- Fixed the object being added to the cameras instead of the War3Camera itself.