### PR TITLE
Add Blender 5.x compatibility and MDX support

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,153 @@
+# MDL Exporter - Blender 5.1 兼容性升级文档
+
+## 概述
+
+将 Warcraft MDL 导入/导出插件从 Blender 2.80 适配到 **Blender 5.1.1**，同时新增 **BLP 贴图直接加载** 功能。
+
+- 仓库来源：`https://github.com/qq200774491/mdl-exporter`（分支 `2.8`）
+- 目标版本：Blender 5.1.1（Python 3.13.9）
+- 工作分支：`blender-5.1-compat`
+
+---
+
+## 修改文件清单
+
+| 文件 | 类型 | 说明 |
+|------|------|------|
+| `export_mdl/__init__.py` | 修改 | `bl_info` 版本号更新 |
+| `export_mdl/blp_reader.py` | **新增** | BLP 贴图解码器（支持 BLP1/BLP2） |
+| `export_mdl/classes/War3AnimationCurve.py` | 修改 | 适配 Blender 5.x 分层 Action 系统 |
+| `export_mdl/classes/War3Model.py` | 修改 | Mesh/Material/Normals API 适配 + BLP 加载 + 原始 bug 修复 |
+| `export_mdl/ui/WAR3_MT_add_object.py` | 修改 | Menu `bl_options` 修复 |
+| `export_mdl/ui/WAR3_PT_billboard_panel.py` | 修改 | LAMP 类型检查更新 |
+
+统计：**6 个文件，275 行新增，46 行删除**
+
+---
+
+## 详细修改内容
+
+### 1. `export_mdl/__init__.py` — 版本号更新
+
+- `"blender": (2, 80, 0)` → `"blender": (4, 0, 0)`
+
+### 2. `export_mdl/blp_reader.py` — BLP 贴图解码器（新增）
+
+新增 223 行的 BLP 格式读取模块，支持：
+
+| 格式 | 压缩类型 | 状态 |
+|------|----------|------|
+| BLP2 | Palette（调色板） | 支持，含 1/4/8 位 alpha |
+| BLP2 | DXT1 | 支持 |
+| BLP2 | DXT3 | 支持 |
+| BLP2 | DXT5 | 支持 |
+| BLP2 | 无压缩 BGRA | 支持 |
+| BLP1 | JPEG | 支持，自动修复 CMYK 通道顺序 |
+| BLP1 | Palette（调色板） | 支持 |
+
+导入时自动查找：先找 `.png`，找不到则自动解码同目录下的 `.blp` 文件。
+
+### 3. `export_mdl/classes/War3AnimationCurve.py` — Action 系统适配
+
+**问题**：Blender 5.x 将 Action 重构为分层系统（Layered Actions），`action.fcurves` 属性不再直接存在于 Action 对象上。
+
+**修复**：新增 `_find_fcurve()` 辅助函数，遍历 `action.layers → strips → channelbags → fcurves` 来查找 FCurve。影响两处：
+- 导入时写入动画后查找 FCurve（`to_fcurves` 方法，第 144 行）
+- 导出时读取动画数据（`get` 方法，第 378 行）
+
+### 4. `export_mdl/classes/War3Model.py` — 核心 API 适配
+
+#### 4.1 Mesh API 适配（Blender 4.0+ 移除的 API）
+
+| 旧 API | 新 API | 原因 |
+|--------|--------|------|
+| `obj.data.use_auto_smooth` | 删除 | Blender 4.1 移除，自动平滑现在始终启用 |
+| `obj.data.auto_smooth_angle` | 删除 | 同上 |
+| `EDGE_SPLIT` modifier | 删除 | 已废弃，由 `sharp_edge` 属性替代 |
+| `mesh.calc_normals_split()` | 删除 | Blender 4.1 移除，法线数据自动可用 |
+| `tri.use_smooth` / `mesh.vertices[v].normal` | `mesh.corner_normals[loop].vector` | 逐角法线，自动处理平滑/锐边 |
+| `mesh.uv_layers.active.data[loop].uv` | `mesh.uv_layers.active.uv[loop].vector` | UV 访问新 API |
+| `polygon.use_smooth = True` | 删除 | 网格默认平滑着色 |
+| `mesh.loops[i].vertex_index` | 保持不变 | 验证仍可用 |
+| `uvs.data[i].uv = (...)` | `uvs.uv[i].vector = (...)` | UV 写入新 API |
+
+#### 4.2 Material API 适配（Blender 4.0 EEVEE-Next）
+
+| 旧 API | 处理 |
+|--------|------|
+| `mat.blend_method` | 删除（EEVEE-Next 移除） |
+| `mat.shadow_method` | 删除（EEVEE-Next 移除） |
+
+#### 4.3 节点查找国际化兼容
+
+| 旧方式 | 新方式 | 原因 |
+|--------|--------|------|
+| `nodes.get('Principled BSDF')` | `next(n for n in nodes if n.type == 'BSDF_PRINCIPLED')` | 中文界面下节点名为"原理化 BSDF" |
+| `nodes.get('Material Output')` | `next(n for n in nodes if n.type == 'OUTPUT_MATERIAL')` | 中文界面下节点名为"材质输出" |
+
+#### 4.4 其他修复
+
+| 修改 | 说明 |
+|------|------|
+| `obj.type in ('LAMP', 'LIGHT')` → `obj.type == 'LIGHT'` | `LAMP` 在 2.80 已重命名 |
+| `obj.data.mdl_data` → `obj.data.mdl_light` | 原始代码 bug：属性名拼写错误 |
+| `context.collection.objects.link(obj)` | 添加重复链接检查，防止 `light_add` 操作符重复链接 |
+| BLP 贴图加载 | 新增 `.blp` 自动解码，含 CMYK→RGB 通道修复 |
+
+### 5. `export_mdl/ui/WAR3_MT_add_object.py` — Menu 选项修复
+
+- `bl_options = {'REGISTER', 'UNDO'}` → `bl_options = {'SEARCH_ON_KEY_PRESS'}`
+- Blender 5.x 不再允许 Menu 类使用 `REGISTER`/`UNDO` 选项
+
+### 6. `export_mdl/ui/WAR3_PT_billboard_panel.py` — 类型检查更新
+
+- `obj.type in ('LAMP', 'LIGHT')` → `obj.type == 'LIGHT'`
+
+---
+
+## 安装方法
+
+将 `export_mdl` 文件夹复制到：
+```
+<Blender安装目录>\5.1\scripts\addons_core\export_mdl\
+```
+
+在 Blender 中启用：**编辑 → 偏好设置 → 插件 → 搜索 "MDL" → 勾选启用**
+
+---
+
+## 使用方法
+
+- **导入**：文件 → 导入 → Warcraft MDL (.mdl)
+- **导出**：文件 → 导出 → Warcraft MDL (.mdl)
+- 导入时自动加载同目录下的 `.blp` 贴图，无需手动转换为 `.png`
+
+---
+
+## 测试结果
+
+| 测试项 | 结果 |
+|--------|------|
+| 插件注册（Blender 5.1.1） | 通过 |
+| MDL 导出（简单模型） | 通过 |
+| MDL 导入（简单模型） | 通过 |
+| MDL 导入（真实模型，50 骨骼 2873 顶点） | 通过 |
+| 导入→导出往返测试（59884 行 MDL） | 通过 |
+| BLP1 JPEG 贴图加载 | 通过 |
+| BLP 颜色通道修复 | 通过 |
+
+---
+
+## 不需要修改的部分（已验证兼容）
+
+- `export_mdl.py`（MDL 文件写入）
+- `import_mdl.py`（MDL 文件解析）
+- `utils.py`
+- 所有 `operators/*.py`
+- 所有 `properties/*.py`
+- 其余 `ui/*.py` 面板
+- `mesh.calc_loop_triangles()` — glTF 插件仍在使用
+- `normals_split_custom_set_from_vertices()` — glTF 插件仍在使用
+- `register_class/unregister_class` 注册模式
+- `TOPBAR_MT_file_export/import` 菜单钩子
+- `orientation_helper` 装饰器

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # mdl-importer/exporter
-Warcraft MDL exporter for Blender
+Warcraft MDL/MDX exporter for Blender
 By Kalle Halvarsson
 
 Now also supports importing!
@@ -9,7 +9,7 @@ Now also supports importing!
 * Add export_mdl folder to a zip or rar file. It should be one next to the "images" folder - not the one containing the full repository!
 * In Blender, go to User Preferences (CTRL+ALT+U) and select "Install Add-on From File". Select your zipped folder.
 * MDL Exporter should now show up in the Import/Export plugins list. Make sure it is enabled by ticking the box.
-* The option to export to .mdl will now appear in the export menu (you may need to restart Blender first).
+* The option to export to .mdl or .mdx will now appear in the export menu (you may need to restart Blender first).
 
 ## Instructions
 This plugin tries to approximate the functionality of the Wc3 Art Tools exporter for 3ds Max. The ambition has been to support multiple ways of achieving the same result, so that users can set up their scene in whatever way feels most intuitive. There are, however, some implementation details you might need to know before using this plugin.

--- a/export_mdl/__init__.py
+++ b/export_mdl/__init__.py
@@ -17,11 +17,11 @@
 # ##### END GPL LICENSE BLOCK #####
 
 bl_info = {
-    "name": "MDL Importer/Exporter", 
+    "name": "MDL/MDX Importer/Exporter", 
     "author": "Kalle Halvarsson",
     "blender": (4, 0, 0),
-    "location": "File > Export > Warcraft MDL (.mdl)",
-    "description": "Import or export Warcraft .MDL models",
+    "location": "File > Import/Export > Warcraft MDL/MDX (.mdl/.mdx)",
+    "description": "Import or export Warcraft .MDL/.MDX models",
     "category": "Import-Export"
     } 
 
@@ -41,11 +41,11 @@ import shutil
         
 def export_menu_func(self, context):
     self.layout.operator_context = 'INVOKE_DEFAULT'
-    self.layout.operator(operators.WAR3_OT_export_mdl.WAR3_OT_export_mdl.bl_idname, text="Warcraft MDL (.mdl)")  
+    self.layout.operator(operators.WAR3_OT_export_mdl.WAR3_OT_export_mdl.bl_idname, text="Warcraft MDL/MDX (.mdl/.mdx)")  
 
 def import_menu_func(self, context):
     self.layout.operator_context = 'INVOKE_DEFAULT'
-    self.layout.operator(operators.WAR3_OT_import_mdl.WAR3_OT_import_mdl.bl_idname, text="Warcraft MDL (.mdl)")  
+    self.layout.operator(operators.WAR3_OT_import_mdl.WAR3_OT_import_mdl.bl_idname, text="Warcraft MDL/MDX (.mdl/.mdx)")  
 
 def register():
     from bpy.utils import register_class

--- a/export_mdl/__init__.py
+++ b/export_mdl/__init__.py
@@ -19,7 +19,7 @@
 bl_info = {
     "name": "MDL Importer/Exporter", 
     "author": "Kalle Halvarsson",
-    "blender": (2, 80, 0),
+    "blender": (4, 0, 0),
     "location": "File > Export > Warcraft MDL (.mdl)",
     "description": "Import or export Warcraft .MDL models",
     "category": "Import-Export"

--- a/export_mdl/blp_reader.py
+++ b/export_mdl/blp_reader.py
@@ -1,0 +1,223 @@
+import struct
+import os
+import tempfile
+import numpy as np
+
+
+def _rgb565(c):
+    r = ((c >> 11) & 0x1F) * 255 // 31
+    g = ((c >> 5) & 0x3F) * 255 // 63
+    b = (c & 0x1F) * 255 // 31
+    return r, g, b
+
+
+def _decode_dxt1(data, w, h):
+    pixels = np.zeros((h, w, 4), dtype=np.uint8)
+    bw, bh = (w + 3) // 4, (h + 3) // 4
+    off = 0
+    for by in range(bh):
+        for bx in range(bw):
+            if off + 8 > len(data):
+                return pixels
+            c0, c1 = struct.unpack_from('<HH', data, off)
+            off += 4
+            r0, g0, b0 = _rgb565(c0)
+            r1, g1, b1 = _rgb565(c1)
+            colors = [(r0, g0, b0, 255), (r1, g1, b1, 255)]
+            if c0 > c1:
+                colors.append(((2*r0+r1)//3, (2*g0+g1)//3, (2*b0+b1)//3, 255))
+                colors.append(((r0+2*r1)//3, (g0+2*g1)//3, (b0+2*b1)//3, 255))
+            else:
+                colors.append(((r0+r1)//2, (g0+g1)//2, (b0+b1)//2, 255))
+                colors.append((0, 0, 0, 0))
+            bits = struct.unpack_from('<I', data, off)[0]
+            off += 4
+            for py in range(4):
+                for px in range(4):
+                    x, y = bx*4+px, by*4+py
+                    if x < w and y < h:
+                        pixels[y, x] = colors[(bits >> (2*(py*4+px))) & 3]
+    return pixels
+
+
+def _decode_dxt3(data, w, h):
+    pixels = np.zeros((h, w, 4), dtype=np.uint8)
+    bw, bh = (w + 3) // 4, (h + 3) // 4
+    off = 0
+    for by in range(bh):
+        for bx in range(bw):
+            if off + 16 > len(data):
+                return pixels
+            alpha_data = data[off:off+8]
+            off += 8
+            c0, c1 = struct.unpack_from('<HH', data, off)
+            off += 4
+            r0, g0, b0 = _rgb565(c0)
+            r1, g1, b1 = _rgb565(c1)
+            colors = [(r0,g0,b0), (r1,g1,b1),
+                      ((2*r0+r1)//3,(2*g0+g1)//3,(2*b0+b1)//3),
+                      ((r0+2*r1)//3,(g0+2*g1)//3,(b0+2*b1)//3)]
+            bits = struct.unpack_from('<I', data, off)[0]
+            off += 4
+            for py in range(4):
+                for px in range(4):
+                    x, y = bx*4+px, by*4+py
+                    if x < w and y < h:
+                        ci = (bits >> (2*(py*4+px))) & 3
+                        ai = py*4+px
+                        abyte = alpha_data[ai//2]
+                        a = ((abyte >> ((ai % 2)*4)) & 0xF) * 17
+                        pixels[y, x] = (*colors[ci], a)
+    return pixels
+
+
+def _decode_dxt5(data, w, h):
+    pixels = np.zeros((h, w, 4), dtype=np.uint8)
+    bw, bh = (w + 3) // 4, (h + 3) // 4
+    off = 0
+    for by in range(bh):
+        for bx in range(bw):
+            if off + 16 > len(data):
+                return pixels
+            a0, a1 = data[off], data[off+1]
+            off += 2
+            abits = int.from_bytes(data[off:off+6], 'little')
+            off += 6
+            alphas = [a0, a1]
+            if a0 > a1:
+                for i in range(1, 7):
+                    alphas.append(((7-i)*a0 + i*a1) // 7)
+            else:
+                for i in range(1, 5):
+                    alphas.append(((5-i)*a0 + i*a1) // 5)
+                alphas.extend([0, 255])
+            c0, c1 = struct.unpack_from('<HH', data, off)
+            off += 4
+            r0, g0, b0 = _rgb565(c0)
+            r1, g1, b1 = _rgb565(c1)
+            colors = [(r0,g0,b0), (r1,g1,b1),
+                      ((2*r0+r1)//3,(2*g0+g1)//3,(2*b0+b1)//3),
+                      ((r0+2*r1)//3,(g0+2*g1)//3,(b0+2*b1)//3)]
+            bits = struct.unpack_from('<I', data, off)[0]
+            off += 4
+            for py in range(4):
+                for px in range(4):
+                    x, y = bx*4+px, by*4+py
+                    if x < w and y < h:
+                        ci = (bits >> (2*(py*4+px))) & 3
+                        ai = py*4+px
+                        a = alphas[(abits >> (3*ai)) & 7]
+                        pixels[y, x] = (*colors[ci], a)
+    return pixels
+
+
+def load_blp(filepath):
+    """Load a BLP file. Returns (width, height, flat_rgba_float_list) or ('jpeg', temp_path) or None."""
+    with open(filepath, 'rb') as f:
+        magic = f.read(4)
+        if magic not in (b'BLP2', b'BLP1'):
+            return None
+
+        if magic == b'BLP2':
+            compression, alpha_depth, alpha_type, has_mips = struct.unpack('<BBBB', f.read(4))
+            width, height = struct.unpack('<II', f.read(8))
+            mip_offsets = struct.unpack('<16I', f.read(64))
+            mip_sizes = struct.unpack('<16I', f.read(64))
+
+            if compression == 1:
+                palette = []
+                for _ in range(256):
+                    b, g, r, a = struct.unpack('<BBBB', f.read(4))
+                    palette.append((r, g, b, a))
+                f.seek(mip_offsets[0])
+                indices = f.read(mip_sizes[0])
+                pixel_count = width * height
+                pixels = np.zeros((pixel_count, 4), dtype=np.uint8)
+
+                color_indices = indices[:pixel_count]
+                for i in range(min(pixel_count, len(color_indices))):
+                    r, g, b, pa = palette[color_indices[i]]
+                    pixels[i] = (r, g, b, 255)
+
+                if alpha_depth == 8 and len(indices) >= pixel_count * 2:
+                    for i in range(pixel_count):
+                        pixels[i, 3] = indices[pixel_count + i]
+                elif alpha_depth == 1:
+                    alpha_start = pixel_count
+                    for i in range(pixel_count):
+                        byte_idx = alpha_start + i // 8
+                        if byte_idx < len(indices):
+                            pixels[i, 3] = 255 if (indices[byte_idx] >> (i % 8)) & 1 else 0
+                elif alpha_depth == 4:
+                    alpha_start = pixel_count
+                    for i in range(pixel_count):
+                        byte_idx = alpha_start + i // 2
+                        if byte_idx < len(indices):
+                            if i % 2 == 0:
+                                pixels[i, 3] = (indices[byte_idx] & 0x0F) * 17
+                            else:
+                                pixels[i, 3] = ((indices[byte_idx] >> 4) & 0x0F) * 17
+
+                pixels = pixels.reshape((height, width, 4))
+
+            elif compression == 2:
+                f.seek(mip_offsets[0])
+                data = f.read(mip_sizes[0])
+                if alpha_type == 0:
+                    pixels = _decode_dxt1(data, width, height)
+                elif alpha_type == 1:
+                    pixels = _decode_dxt3(data, width, height)
+                else:
+                    pixels = _decode_dxt5(data, width, height)
+
+            elif compression == 3:
+                f.seek(mip_offsets[0])
+                data = f.read(width * height * 4)
+                pixels = np.frombuffer(data, dtype=np.uint8).reshape((height, width, 4))
+                pixels = pixels[:, :, [2, 1, 0, 3]]
+            else:
+                return None
+
+            flat = (pixels.reshape(-1).astype(np.float32) / 255.0).tolist()
+            return width, height, flat
+
+        else:
+            # BLP1
+            compression = struct.unpack('<I', f.read(4))[0]
+            alpha_depth = struct.unpack('<I', f.read(4))[0]
+            width = struct.unpack('<I', f.read(4))[0]
+            height = struct.unpack('<I', f.read(4))[0]
+            flags = struct.unpack('<I', f.read(4))[0]
+            has_mips = struct.unpack('<I', f.read(4))[0]
+            mip_offsets = struct.unpack('<16I', f.read(64))
+            mip_sizes = struct.unpack('<16I', f.read(64))
+
+            if compression == 0:
+                # JPEG - save to temp file for Blender to load
+                jpeg_header_size = struct.unpack('<I', f.read(4))[0]
+                jpeg_header = f.read(jpeg_header_size)
+                f.seek(mip_offsets[0])
+                mip_data = f.read(mip_sizes[0])
+                full_jpeg = jpeg_header + mip_data
+
+                tmp = os.path.join(tempfile.gettempdir(), '_blp_temp.jpg')
+                with open(tmp, 'wb') as out:
+                    out.write(full_jpeg)
+                return 'jpeg', tmp
+
+            elif compression == 1:
+                palette = []
+                for _ in range(256):
+                    b, g, r, a = struct.unpack('<BBBB', f.read(4))
+                    palette.append((r, g, b, a))
+                f.seek(mip_offsets[0])
+                indices = f.read(mip_sizes[0])
+                pixel_count = width * height
+                pixels = np.zeros((pixel_count, 4), dtype=np.uint8)
+                for i in range(min(pixel_count, len(indices))):
+                    pixels[i] = palette[indices[i]]
+                pixels = pixels.reshape((height, width, 4))
+                flat = (pixels.reshape(-1).astype(np.float32) / 255.0).tolist()
+                return width, height, flat
+
+            return None

--- a/export_mdl/classes/War3AnimationCurve.py
+++ b/export_mdl/classes/War3AnimationCurve.py
@@ -5,6 +5,15 @@ from mathutils import Quaternion, Matrix, Euler, Vector
 
 from ..utils import *
 
+def _find_fcurve(action, data_path, index=0):
+    for layer in action.layers:
+        for strip in layer.strips:
+            for channelbag in strip.channelbags:
+                fc = channelbag.fcurves.find(data_path, index=index)
+                if fc is not None:
+                    return fc
+    return None
+
 class War3AnimationCurve:
     def __init__(self):
         self.interpolation = 'Linear'
@@ -132,7 +141,7 @@ class War3AnimationCurve:
             target.keyframe_insert(data_path, frame=frame)
 
         for channel in range(num_channels):
-            curve = anim_data_obj.animation_data.action.fcurves.find(full_data_path, index=channel)
+            curve = _find_fcurve(anim_data_obj.animation_data.action, full_data_path, index=channel)
 
             if curve is None:
                 print("Missing curve for object %s, data path %s, channel %d" % (anim_data_obj.name, data_path, channel))
@@ -366,7 +375,7 @@ class War3AnimationCurve:
    
         if anim_data and anim_data.action:
             for index in range(num_indices):
-                curve = anim_data.action.fcurves.find(data_path, index=index)
+                curve = _find_fcurve(anim_data.action, data_path, index=index)
                 if curve is not None:
                     curves[(data_path.split('.')[-1], index)] = curve # For now, i'm just interested in the type, not the whole data path. Hence, the split returns the name after the last dot. 
             

--- a/export_mdl/classes/War3EventObject.py
+++ b/export_mdl/classes/War3EventObject.py
@@ -5,4 +5,4 @@ class War3EventObject(War3Object):
     def __init__(self, name):
         War3Object.__init__(self, name)
         
-        self.track: War3AnimationCurve
+        self.track: War3AnimationCurve = None

--- a/export_mdl/classes/War3Light.py
+++ b/export_mdl/classes/War3Light.py
@@ -11,3 +11,9 @@ class War3Light(War3Object):
         self.color = (1, 1, 1)
         self.amb_color = (0, 0, 0)
         self.amb_intensity = 0
+        self.intensity_anim = None
+        self.atten_start_anim = None
+        self.atten_end_anim = None
+        self.color_anim = None
+        self.amb_color_anim = None
+        self.amb_intensity_anim = None

--- a/export_mdl/classes/War3Model.py
+++ b/export_mdl/classes/War3Model.py
@@ -53,21 +53,11 @@ class War3Model:
         
     @staticmethod
     def prepare_mesh(obj, context, matrix):
-        mod = None
-        if obj.data.use_auto_smooth:
-            mod = obj.modifiers.new("EdgeSplitExport", 'EDGE_SPLIT')
-            mod.split_angle = obj.data.auto_smooth_angle
-        
         depsgraph = context.evaluated_depsgraph_get()
-        mesh =  bpy.data.meshes.new_from_object(obj.evaluated_get(depsgraph), preserve_all_data_layers=True, depsgraph=depsgraph)
-        
-        if obj.data.use_auto_smooth:
-            obj.modifiers.remove(mod)
+        mesh = bpy.data.meshes.new_from_object(obj.evaluated_get(depsgraph), preserve_all_data_layers=True, depsgraph=depsgraph)
 
-        # Triangulate for web export
         bm = bmesh.new()
         bm.from_mesh(mesh)
-        # If an object has had a negative scale applied, normals will be inverted. This will fix that. 
         if any(s < 0 for s in obj.scale):
             bmesh.ops.recalc_face_normals(bm, faces=bm.faces)
         bmesh.ops.triangulate(bm, faces=bm.faces)
@@ -76,7 +66,6 @@ class War3Model:
         bm.free()
         del bm
 
-        mesh.calc_normals_split()
         mesh.calc_loop_triangles()
 
         return mesh
@@ -334,9 +323,9 @@ class War3Model:
                     for vert, loop in zip(tri.vertices, tri.loops):
                         co = mesh.vertices[vert].co
                         coord = (rnd(co.x), rnd(co.y), rnd(co.z))
-                        n = mesh.vertices[vert].normal if tri.use_smooth else tri.normal
+                        n = mesh.corner_normals[loop].vector
                         norm = (rnd(n.x), rnd(n.y), rnd(n.z))
-                        uv = mesh.uv_layers.active.data[loop].uv if len(mesh.uv_layers) else Vector((0.0, 0.0))
+                        uv = mesh.uv_layers.active.uv[loop].vector if len(mesh.uv_layers) else Vector((0.0, 0.0))
                         uv[1] = 1 - uv[1] # For some reason, uv Y coordinates appear flipped. This should fix that. 
                         tvert = (rnd(uv.x), rnd(uv.y))
                         groups = None
@@ -504,7 +493,7 @@ class War3Model:
                     
                     self.objects['bone'].add(bone)
                     
-            elif obj.type in ('LAMP', 'LIGHT'):
+            elif obj.type == 'LIGHT':
                 light = War3Light(obj.name)
                 light.object = obj
                 light.pivot = settings.global_matrix @ Vector(obj.location)
@@ -659,9 +648,11 @@ class War3Model:
             nodes = mat.node_tree.nodes
             links = mat.node_tree.links
 
-            nodes.remove(nodes.get('Principled BSDF'))
+            for n in list(nodes):
+                if n.type == 'BSDF_PRINCIPLED':
+                    nodes.remove(n)
 
-            output = nodes.get('Material Output')
+            output = next(n for n in nodes if n.type == 'OUTPUT_MATERIAL')
             output.location = Vector((0, 0))
 
             mix_node = nodes.new('ShaderNodeMixShader')
@@ -791,19 +782,38 @@ class War3Model:
 
                     image_name = os.path.basename(texture.image_path.replace('.blp', '.png'))
                     import_path = os.path.join(folder, image_name)
+                    blp_name = os.path.basename(texture.image_path)
+                    blp_path = os.path.join(folder, blp_name)
 
                     node = nodes.new('ShaderNodeTexImage')
                     node.name = image_name
 
                     if image_name in bpy.data.images:
                         node.image = bpy.data.images[image_name]
-                    else:
-                        print("Loading image: %s" % import_path)
-                        if os.path.exists(import_path):
-                            img = bpy.data.images.load(import_path)
+                    elif os.path.exists(import_path):
+                        node.image = bpy.data.images.load(import_path)
+                    elif os.path.exists(blp_path):
+                        from ..blp_reader import load_blp
+                        result = load_blp(blp_path)
+                        if result and result[0] == 'jpeg':
+                            img = bpy.data.images.load(result[1])
+                            img.name = image_name
+                            px = list(img.pixels)
+                            for i in range(0, len(px), 4):
+                                px[i], px[i+2] = px[i+2], px[i]
+                            img.pixels = px
+                            img.pack()
+                            node.image = img
+                        elif result:
+                            w, h, px = result
+                            img = bpy.data.images.new(image_name, w, h, alpha=True)
+                            img.pixels = px
+                            img.pack()
                             node.image = img
                         else:
-                            print("Image at path %s does not exist!" % import_path)
+                            print("Failed to decode BLP: %s" % blp_path)
+                    else:
+                        print("Image not found: %s" % import_path)
 
                 node.location = offset
 
@@ -857,16 +867,6 @@ class War3Model:
             last_index = len(material.layers) - 1
             last_node = create_join(last_index, last_index-1, Vector((x_offset - 400, 0)))
             links.new(last_node.outputs[0], input_socket)
-
-            if any(True for layer in material.layers if layer.filter_mode == 'None'):
-                mat.blend_method = 'OPAQUE'
-                mat.shadow_method = 'OPAQUE'
-            elif any(True for layer in material.layers if layer.filter_mode == 'Transparent'):
-                mat.blend_method = 'CLIP'
-                mat.shadow_method = 'CLIP'
-            else:
-                mat.blend_method = 'BLEND'
-                mat.shadow_method = 'NONE'
 
             if len([True for layer in material.layers if layer.filter_mode == 'None']) == 0:
                 if last_node.outputs.get('Alpha') is not None:
@@ -974,17 +974,13 @@ class War3Model:
 
             is_skinned = len(geoset.matrices) > 1
 
-            # Mesh will already have split nornals, rest should be smooth
-            for f in mesh.polygons:
-                f.use_smooth = True
-
             # UVs
             uvs = mesh.uv_layers.new(name='UV')
             for face in mesh.polygons:
                 for loop_index in range(face.loop_start, face.loop_start + face.loop_total):
-                    loop = mesh.loops[loop_index]
-                    uv = geoset.vertices[loop.vertex_index][2]
-                    uvs.data[loop_index].uv = (uv[0], 1 - uv[1]) # UV Y is flipped in MDL source
+                    vert_idx = mesh.loops[loop_index].vertex_index
+                    uv = geoset.vertices[vert_idx][2]
+                    uvs.uv[loop_index].vector = (uv[0], 1 - uv[1])
 
             # Normals
             mesh.normals_split_custom_set_from_vertices(normals)
@@ -1104,7 +1100,7 @@ class War3Model:
                 elif node_type == 'light':
                     bpy.ops.object.light_add(type='POINT', radius=1.0, align='WORLD', location=pivot)
                     obj = context.active_object
-                    light_data = obj.data.mdl_data
+                    light_data = obj.data.mdl_light
                     light_data.atten_start = node.atten_start
                     light_data.atten_end = node.atten_end
                     if node.color is not None:
@@ -1209,7 +1205,8 @@ class War3Model:
 
                 obj.location = pivot
 
-                context.collection.objects.link(obj)
+                if obj.name not in context.collection.objects:
+                    context.collection.objects.link(obj)
 
                 if node.anim_loc is not None:
                     node.anim_loc.to_fcurves(obj, obj, 'location', 'location', global_matrix)

--- a/export_mdl/classes/War3Model.py
+++ b/export_mdl/classes/War3Model.py
@@ -28,7 +28,7 @@ from ..utils import *
 
 class War3Model:
 
-    default_texture = "Textures\white.blp"
+    default_texture = r"Textures\white.blp"
     decimal_places = 5
 
     def __init__(self, context):
@@ -825,8 +825,8 @@ class War3Model:
                     if len(node.inputs): # No inputs on RGB node
                         links.new(node.inputs[0], mapping_node.outputs[0])
 
-                    if texture_anim.location is not None:
-                        texture_anim.location.to_fcurves(mapping_node.inputs["Location"], mat.node_tree, 'default_value', 'mapping_node.inputs["Location"]')
+                    if texture_anim.translation is not None:
+                        texture_anim.translation.to_fcurves(mapping_node.inputs["Location"], mat.node_tree, 'default_value', 'mapping_node.inputs["Location"]')
                     if texture_anim.rotation is not None: # TODO: Needs to convert from quaternion to euler!
                         texture_anim.rotation.to_fcurves(mapping_node.inputs["Rotation"], mat.node_tree, 'default_value', 'mapping_node.inputs["Rotation"]')
                     if texture_anim.scale is not None:
@@ -927,7 +927,7 @@ class War3Model:
 
         def animate_bone(node):
             pose_bone = armature_obj.pose.bones[node.name]
-            matrix = pose_bone.bone.matrix_local.inverted()
+            matrix = pose_bone.bone.matrix_local.inverted_safe()
             if node.anim_loc is not None:
                 matrix = matrix.to_3x3().to_4x4() @ global_matrix
                 node.anim_loc.to_fcurves(pose_bone, armature_obj, 'location', 'pose.bones["%s"].location' % node.name, matrix)
@@ -1093,8 +1093,8 @@ class War3Model:
                         if node.type == 'Sphere':
                             obj.scale = global_matrix.to_3x3() @ Vector((node.radius, node.radius, node.radius))
                         else:
-                            pmin = global_matrix @ Vector(obj.vertices[0])
-                            pmax = global_matrix @ Vector(obj.vertices[1])
+                            pmin = global_matrix @ Vector(node.vertices[0])
+                            pmax = global_matrix @ Vector(node.vertices[1])
                             obj.scale = (abs(pmax[0] - pmin[0]), abs(pmax[1] - pmin[1]), abs(pmax[2] - pmin[2]))
 
                 elif node_type == 'light':
@@ -1224,10 +1224,12 @@ class War3Model:
         context.view_layer.update()
         for node_type in self.objects:
             for node in self.objects[node_type]:
+                if node.object_id not in objects:
+                    continue
                 child = objects[node.object_id]
                 if child in bone_armature:
                     continue # Parenting of armature bones already handled - plus, the object will be a string
-                if node.parent_id is not None:
+                if node.parent_id is not None and node.parent_id in objects:
                     if objects[node.parent_id] in bone_armature:
                         bone_name = objects[node.parent_id]
                         armature = bone_armature[bone_name]
@@ -1237,6 +1239,8 @@ class War3Model:
                         child.matrix_parent_inverse = armature.data.bones[bone_name].matrix_local.inverted()
                     else:
                         parent = objects[node.parent_id]
+                        if parent == child:
+                            continue
                         child.parent_type = 'OBJECT'
                         child.parent = parent
                         child.matrix_parent_inverse = parent.matrix_world.inverted()

--- a/export_mdl/export_mdx.py
+++ b/export_mdl/export_mdx.py
@@ -1,0 +1,560 @@
+import io
+import struct
+
+import bpy
+
+from .classes.War3Model import War3Model
+from .utils import calc_bounds_radius
+
+
+INTERPOLATIONS = {
+    "DontInterp": 0,
+    "None": 0,
+    "Linear": 1,
+    "Hermite": 2,
+    "Bezier": 3,
+}
+
+FILTER_MODES = {
+    "None": 0,
+    "Transparent": 1,
+    "Blend": 2,
+    "Additive": 3,
+    "AddAlpha": 4,
+    "Modulate": 5,
+    "Modulate2x": 6,
+}
+
+LIGHT_TYPES = {
+    "Omnidirectional": 0,
+    "Directional": 1,
+    "Ambient": 2,
+}
+
+NODE_FLAGS = {
+    "helper": 0x000,
+    "bone": 0x100,
+    "light": 0x200,
+    "eventobject": 0x400,
+    "attachment": 0x800,
+    "particle": 0x1000,
+    "collisionshape": 0x2000,
+    "ribbon": 0x4000,
+}
+
+
+class MDXWriter:
+    def __init__(self):
+        self.buffer = io.BytesIO()
+
+    def tell(self):
+        return self.buffer.tell()
+
+    def write(self, data):
+        self.buffer.write(data)
+
+    def u32(self, value):
+        self.write(struct.pack("<I", int(value)))
+
+    def u16(self, value):
+        self.write(struct.pack("<H", int(value)))
+
+    def i32(self, value):
+        self.write(struct.pack("<i", int(value)))
+
+    def f32(self, value):
+        self.write(struct.pack("<f", float(value)))
+
+    def vec2(self, value):
+        self.write(struct.pack("<2f", float(value[0]), float(value[1])))
+
+    def vec3(self, value):
+        self.write(struct.pack("<3f", float(value[0]), float(value[1]), float(value[2])))
+
+    def vec4(self, value):
+        self.write(struct.pack("<4f", float(value[0]), float(value[1]), float(value[2]), float(value[3])))
+
+    def fixed_string(self, value, size):
+        encoded = (value or "").encode("utf-8")[: size - 1]
+        self.write(encoded)
+        self.write(b"\0" * (size - len(encoded)))
+
+    def chunk(self, name):
+        return SizedBlock(self, name.encode("ascii"), include_tag=True)
+
+    def sized(self):
+        return SizedBlock(self, None, include_tag=False)
+
+    def save(self, filepath):
+        with open(filepath, "wb") as file:
+            file.write(self.buffer.getvalue())
+
+
+class SizedBlock:
+    def __init__(self, writer, tag, include_tag):
+        self.writer = writer
+        self.tag = tag
+        self.include_tag = include_tag
+        self.size_position = None
+        self.data_position = None
+
+    def __enter__(self):
+        if self.include_tag:
+            self.writer.write(self.tag)
+        self.size_position = self.writer.tell()
+        self.writer.u32(0)
+        self.data_position = self.writer.tell()
+        return self
+
+    def __exit__(self, exc_type, exc, traceback):
+        end_position = self.writer.tell()
+        size = end_position - self.data_position
+        current = self.writer.tell()
+        self.writer.buffer.seek(self.size_position)
+        self.writer.u32(size)
+        self.writer.buffer.seek(current)
+
+
+def _ms_frame(frame):
+    return int(frame * 1000 / bpy.context.scene.render.fps)
+
+
+def _object_id(model, obj):
+    return model.object_indices.get(obj.name, obj.object_id)
+
+
+def _parent_id(model, obj):
+    if obj.parent is None:
+        return -1
+    return model.object_indices[obj.parent]
+
+
+def _node_flags(kind, obj):
+    flags = NODE_FLAGS[kind]
+    if getattr(obj, "billboarded", False):
+        flags |= 0x008
+    lock_x, lock_y, lock_z = getattr(obj, "billboard_lock", (False, False, False))
+    if lock_x:
+        flags |= 0x010
+    if lock_y:
+        flags |= 0x020
+    if lock_z:
+        flags |= 0x040
+    return flags
+
+
+def _write_extent(writer, minimum, maximum):
+    writer.f32(calc_bounds_radius(minimum, maximum))
+    writer.vec3(minimum)
+    writer.vec3(maximum)
+
+
+def _write_track(writer, tag, curve, model, dimensions=None, transform=None, index=None, base_value=1):
+    if curve is None:
+        return
+
+    writer.write(tag.encode("ascii"))
+    writer.u32(len(curve.keyframes))
+    writer.u32(INTERPOLATIONS.get(curve.interpolation, 1))
+    writer.i32(model.global_seqs.index(curve.global_sequence) if curve.global_sequence > 0 else -1)
+
+    for frame in sorted(curve.keyframes.keys()):
+        writer.u32(_ms_frame(frame))
+        if dimensions == 0:
+            continue
+        value = curve.keyframes[frame]
+        if index is not None:
+            value = (value[index] * base_value,)
+        elif transform is not None:
+            value = transform(value)
+        _write_track_value(writer, value, dimensions)
+
+        if curve.interpolation in {"Hermite", "Bezier"}:
+            in_tan = curve.handles_left[frame]
+            out_tan = curve.handles_right[frame]
+            if index is not None:
+                in_tan = (in_tan[index] * base_value,)
+                out_tan = (out_tan[index] * base_value,)
+            elif transform is not None:
+                in_tan = transform(in_tan)
+                out_tan = transform(out_tan)
+            _write_track_value(writer, in_tan, dimensions)
+            _write_track_value(writer, out_tan, dimensions)
+
+
+def _write_track_value(writer, value, dimensions=None):
+    if dimensions == 1 or len(value) == 1:
+        writer.f32(value[0])
+    elif dimensions == 2:
+        writer.vec2(value)
+    elif dimensions == 3:
+        writer.vec3(value)
+    elif dimensions == 4:
+        writer.vec4(value)
+    else:
+        writer.write(struct.pack("<%df" % len(value), *[float(v) for v in value]))
+
+
+def _rotation_xyzw(value):
+    return tuple(value[1:]) + (value[0],)
+
+
+def _color_bgr(value):
+    return tuple(reversed(value[:3]))
+
+
+def _write_node(writer, model, obj, kind, display_name=None):
+    writer.fixed_string(display_name or obj.name, 80)
+    writer.u32(_object_id(model, obj))
+    writer.i32(_parent_id(model, obj))
+    writer.u32(_node_flags(kind, obj))
+    _write_track(writer, "KGTR", obj.anim_loc, model, 3)
+    _write_track(writer, "KGRT", obj.anim_rot, model, 4, transform=_rotation_xyzw)
+    _write_track(writer, "KGSC", obj.anim_scale, model, 3)
+
+
+def _write_model(writer, model, mdl_version):
+    writer.write(b"MDLX")
+
+    with writer.chunk("VERS"):
+        writer.u32(mdl_version)
+
+    with writer.chunk("MODL"):
+        writer.fixed_string(model.name, 80)
+        writer.fixed_string("", 260)
+        _write_extent(writer, model.global_extents_min, model.global_extents_max)
+        writer.u32(150)
+
+    if model.sequences:
+        with writer.chunk("SEQS"):
+            for sequence in model.sequences:
+                writer.fixed_string(sequence.name, 80)
+                writer.u32(sequence.start)
+                writer.u32(sequence.end)
+                writer.f32(sequence.movement_speed if "walk" in sequence.name.lower() else 0)
+                writer.u32(1 if sequence.non_looping else 0)
+                writer.f32(sequence.rarity)
+                writer.u32(0)
+                _write_extent(writer, model.global_extents_min, model.global_extents_max)
+
+    if model.global_seqs:
+        with writer.chunk("GLBS"):
+            for sequence in model.global_seqs:
+                writer.u32(sequence)
+
+    if model.textures:
+        with writer.chunk("TEXS"):
+            for texture in model.textures:
+                writer.u32(texture.replaceable_id if texture.is_replaceable else 0)
+                writer.fixed_string("" if texture.is_replaceable else texture.image_path, 260)
+                writer.u32(0x3)
+
+    if model.materials:
+        with writer.chunk("MTLS"):
+            for material in model.materials:
+                with writer.sized():
+                    writer.u32(material.priority_plane)
+                    flags = 0x1 if material.use_const_color else 0
+                    writer.u32(flags)
+                    writer.write(b"LAYS")
+                    writer.u32(len(material.layers))
+                    for layer in material.layers:
+                        with writer.sized():
+                            flags = 0
+                            flags |= 0x1 if layer.unshaded else 0
+                            flags |= 0x10 if layer.two_sided else 0
+                            flags |= 0x20 if layer.unfogged else 0
+                            flags |= 0x40 if layer.no_depth_test else 0
+                            flags |= 0x80 if layer.no_depth_set else 0
+                            writer.u32(FILTER_MODES.get(layer.filter_mode, 0))
+                            writer.u32(flags)
+                            writer.u32(layer.texture_id or 0)
+                            writer.u32(model.tvertex_anims.index(layer.texture_anim) if layer.texture_anim in model.tvertex_anims else -1)
+                            writer.u32(0)
+                            writer.f32(layer.alpha_value)
+                            _write_track(writer, "KMTA", layer.alpha_anim, model, 1)
+
+    if model.tvertex_anims:
+        with writer.chunk("TXAN"):
+            for anim in model.tvertex_anims:
+                with writer.sized():
+                    _write_track(writer, "KTAT", anim.translation, model, 3)
+                    _write_track(writer, "KTAR", anim.rotation, model, 4, transform=_rotation_xyzw)
+                    _write_track(writer, "KTAS", anim.scale, model, 3)
+
+    if model.geosets:
+        with writer.chunk("GEOS"):
+            for geoset in model.geosets:
+                _write_geoset(writer, model, geoset)
+
+    if model.geoset_anims:
+        with writer.chunk("GEOA"):
+            for anim in model.geoset_anims:
+                with writer.sized():
+                    writer.f32(1.0)
+                    writer.u32(0)
+                    writer.vec3(_color_bgr(anim.color) if anim.color is not None else (1, 1, 1))
+                    writer.u32(model.geosets.index(anim.geoset))
+                    _write_track(writer, "KGAO", anim.alpha_anim, model, 1)
+                    _write_track(writer, "KGAC", anim.color_anim, model, 3, transform=_color_bgr)
+
+    _write_objects(writer, model)
+
+
+def _write_geoset(writer, model, geoset):
+    with writer.sized():
+        writer.write(b"VRTX")
+        writer.u32(len(geoset.vertices))
+        for vertex in geoset.vertices:
+            writer.vec3(vertex[0])
+
+        writer.write(b"NRMS")
+        writer.u32(len(geoset.vertices))
+        for vertex in geoset.vertices:
+            writer.vec3(vertex[1])
+
+        writer.write(b"PTYP")
+        writer.u32(1)
+        writer.u32(4)
+
+        writer.write(b"PCNT")
+        writer.u32(1)
+        writer.u32(len(geoset.triangles) * 3)
+
+        writer.write(b"PVTX")
+        writer.u32(len(geoset.triangles) * 3)
+        for triangle in geoset.triangles:
+            for index in triangle:
+                writer.u16(index)
+
+        writer.write(b"GNDX")
+        writer.u32(len(geoset.vertices))
+        for vertex in geoset.vertices:
+            writer.write(struct.pack("<B", int(vertex[3])))
+
+        writer.write(b"MTGC")
+        writer.u32(len(geoset.matrices))
+        for matrix in geoset.matrices:
+            writer.u32(len(matrix))
+
+        writer.write(b"MATS")
+        matrix_indices = [model.object_indices[name] for matrix in geoset.matrices for name in matrix]
+        writer.u32(len(matrix_indices))
+        for index in matrix_indices:
+            writer.u32(index)
+
+        writer.u32(model.materials.index(next(mat for mat in model.materials if mat.name == geoset.mat_name)))
+        writer.u32(0)
+        _write_extent(writer, geoset.min_extent, geoset.max_extent)
+        writer.u32(len(model.sequences))
+        for _sequence in model.sequences:
+            _write_extent(writer, geoset.min_extent, geoset.max_extent)
+
+        writer.write(b"UVAS")
+        writer.u32(1)
+        writer.write(b"UVBS")
+        writer.u32(len(geoset.vertices))
+        for vertex in geoset.vertices:
+            writer.vec2(vertex[2])
+
+
+def _write_objects(writer, model):
+    if model.objects["bone"]:
+        with writer.chunk("BONE"):
+            for bone in model.objects["bone"]:
+                display_name = bone.name.replace(".", "_")
+                if not display_name.lower().startswith("bone"):
+                    display_name = "Bone_" + display_name
+                with writer.sized():
+                    _write_node(writer, model, bone, "bone", display_name)
+                    children = [g for g in model.geosets if bone.name in [n for matrix in g.matrices for n in matrix]]
+                    writer.i32(model.geosets.index(children[0]) if len(children) == 1 else -1)
+                    writer.i32(model.geoset_anims.index(model.geoset_anim_map[bone.name]) if bone.name in model.geoset_anim_map else -1)
+
+    if model.objects["light"]:
+        with writer.chunk("LITE"):
+            for light in model.objects["light"]:
+                with writer.sized():
+                    _write_node(writer, model, light, "light")
+                    writer.u32(LIGHT_TYPES.get(light.type, 0))
+                    writer.f32(light.atten_start)
+                    writer.f32(light.atten_end)
+                    writer.vec3(_color_bgr(light.color))
+                    writer.f32(light.intensity)
+                    writer.vec3(_color_bgr(light.amb_color))
+                    writer.f32(light.amb_intensity)
+                    _write_track(writer, "KLAS", light.atten_start_anim, model, 1)
+                    _write_track(writer, "KLAE", light.atten_end_anim, model, 1)
+                    _write_track(writer, "KLAC", light.color_anim, model, 3, transform=_color_bgr)
+                    _write_track(writer, "KLAI", light.intensity_anim, model, 1)
+                    _write_track(writer, "KLBI", light.amb_intensity_anim, model, 1)
+                    _write_track(writer, "KLBC", light.amb_color_anim, model, 3, transform=_color_bgr)
+                    _write_track(writer, "KLAV", light.visibility, model, 1)
+
+    if model.objects["helper"]:
+        with writer.chunk("HELP"):
+            for helper in model.objects["helper"]:
+                display_name = helper.name.replace(".", "_")
+                if not display_name.lower().startswith("bone"):
+                    display_name = "Bone_" + display_name
+                with writer.sized():
+                    _write_node(writer, model, helper, "helper", display_name)
+
+    if model.objects["attachment"]:
+        with writer.chunk("ATCH"):
+            for index, attachment in enumerate(model.objects["attachment"]):
+                with writer.sized():
+                    _write_node(writer, model, attachment, "attachment")
+                    writer.fixed_string("", 260)
+                    writer.u32(index)
+                    _write_track(writer, "KATV", attachment.visibility, model, 1)
+
+    if model.objects_all:
+        with writer.chunk("PIVT"):
+            for obj in model.objects_all:
+                writer.vec3(obj.pivot)
+
+    if model.objects["particle"]:
+        with writer.chunk("PREM"):
+            for psys in model.objects["particle"]:
+                with writer.sized():
+                    _write_node(writer, model, psys, "particle")
+                    writer.f32(psys.emission_rate)
+                    writer.f32(psys.gravity)
+                    writer.f32(psys.longitude)
+                    writer.f32(psys.latitude)
+                    writer.fixed_string(psys.model_path, 260)
+                    writer.f32(psys.life_span)
+                    writer.f32(psys.speed)
+                    _write_track(writer, "KPEE", psys.emission_rate_anim, model, 1)
+                    _write_track(writer, "KPEG", psys.gravity_anim, model, 1)
+                    _write_track(writer, "KPLN", psys.longitude_anim, model, 1)
+                    _write_track(writer, "KPLT", psys.latitude_anim, model, 1)
+                    _write_track(writer, "KPEV", psys.visibility, model, 1)
+                    _write_track(writer, "KPEL", psys.life_span_anim, model, 1)
+                    _write_track(writer, "KPES", psys.speed_anim, model, 1)
+
+    if model.objects["particle2"]:
+        with writer.chunk("PRE2"):
+            for psys in model.objects["particle2"]:
+                with writer.sized():
+                    _write_node(writer, model, psys, "particle")
+                    writer.f32(psys.speed)
+                    writer.f32(psys.variation)
+                    writer.f32(psys.latitude)
+                    writer.f32(psys.gravity)
+                    writer.f32(psys.life_span)
+                    writer.f32(psys.emission_rate)
+                    writer.f32(psys.dimensions[1])
+                    writer.f32(psys.dimensions[0])
+                    writer.u32(FILTER_MODES.get(psys.filter_mode, 2))
+                    writer.u32(psys.rows)
+                    writer.u32(psys.cols)
+                    writer.u32(2 if psys.head and psys.tail else 1 if psys.tail else 0)
+                    writer.f32(psys.tail_length)
+                    writer.f32(psys.time)
+                    writer.vec3(_color_bgr(psys.start_color))
+                    writer.vec3(_color_bgr(psys.mid_color))
+                    writer.vec3(_color_bgr(psys.end_color))
+                    writer.write(struct.pack("<3B", int(psys.start_alpha), int(psys.mid_alpha), int(psys.end_alpha)))
+                    writer.write(b"\0")
+                    writer.vec3((psys.start_scale, psys.mid_scale, psys.end_scale))
+                    for values in (
+                        (psys.head_life_start, psys.head_life_end, psys.head_life_repeat),
+                        (psys.head_decay_start, psys.head_decay_end, psys.head_decay_repeat),
+                        (psys.tail_life_start, psys.tail_life_end, psys.tail_life_repeat),
+                        (psys.tail_decay_start, psys.tail_decay_end, psys.tail_decay_repeat),
+                    ):
+                        writer.u32(values[0])
+                        writer.u32(values[1])
+                        writer.u32(values[2])
+                    writer.u32(psys.texture_id)
+                    writer.u32(psys.priority_plane)
+                    flags = 0
+                    flags |= 0x10000 if psys.sort_far_z else 0
+                    flags |= 0x8000 if psys.unshaded else 0
+                    flags |= 0x20000 if psys.line_emitter else 0
+                    flags |= 0x40000 if psys.unfogged else 0
+                    flags |= 0x80000 if psys.model_space else 0
+                    flags |= 0x100000 if psys.xy_quad else 0
+                    writer.u32(flags)
+                    _write_track(writer, "KP2S", psys.speed_anim, model, 1)
+                    _write_track(writer, "KP2R", psys.variation_anim, model, 1)
+                    _write_track(writer, "KP2L", psys.latitude_anim, model, 1)
+                    _write_track(writer, "KP2G", psys.gravity_anim, model, 1)
+                    _write_track(writer, "KP2V", psys.visibility, model, 1)
+                    _write_track(writer, "KP2E", psys.emission_rate_anim, model, 1)
+                    _write_track(writer, "KP2W", psys.scale_anim, model, 1, index=1, base_value=psys.dimensions[1])
+                    _write_track(writer, "KP2N", psys.scale_anim, model, 1, index=0, base_value=psys.dimensions[0])
+
+    if model.objects["ribbon"]:
+        with writer.chunk("RIBB"):
+            for psys in model.objects["ribbon"]:
+                with writer.sized():
+                    _write_node(writer, model, psys, "ribbon")
+                    writer.f32(psys.dimensions[0] / 2)
+                    writer.f32(psys.dimensions[0] / 2)
+                    writer.f32(psys.alpha)
+                    writer.vec3(_color_bgr(psys.ribbon_color))
+                    writer.f32(psys.life_span)
+                    writer.u32(psys.texture_id)
+                    for material in model.materials:
+                        if material.name == psys.ribbon_material.name:
+                            writer.u32(model.materials.index(material))
+                            break
+                    else:
+                        writer.u32(0)
+                    writer.u32(psys.rows)
+                    writer.u32(psys.cols)
+                    writer.f32(psys.emission_rate)
+                    writer.f32(psys.gravity)
+                    _write_track(writer, "KRHA", None, model, 1)
+                    _write_track(writer, "KRHB", None, model, 1)
+                    _write_track(writer, "KRAL", psys.alpha_anim, model, 1)
+                    _write_track(writer, "KRCO", psys.ribbon_color_anim, model, 3, transform=_color_bgr)
+                    _write_track(writer, "KRVS", psys.visibility, model, 1)
+
+    if model.cameras:
+        with writer.chunk("CAMS"):
+            for camera in model.cameras:
+                with writer.sized():
+                    writer.fixed_string(camera.name, 80)
+                    writer.vec3(camera.pivot)
+                    writer.f32(camera.field_of_view)
+                    writer.f32(camera.far_clip)
+                    writer.f32(camera.near_clip)
+                    writer.vec3(camera.target)
+
+    if model.objects["eventobject"]:
+        with writer.chunk("EVTS"):
+            for event in model.objects["eventobject"]:
+                with writer.sized():
+                    _write_node(writer, model, event, "eventobject")
+                    _write_track(writer, "KEVT", event.track, model, 0)
+
+    if model.objects["collisionshape"]:
+        with writer.chunk("CLID"):
+            for collider in model.objects["collisionshape"]:
+                with writer.sized():
+                    _write_node(writer, model, collider, "collisionshape")
+                    writer.u32(0 if collider.type == "Box" else 2)
+                    if collider.type == "Box":
+                        for vertex in collider.verts:
+                            writer.vec3(vertex)
+                    else:
+                        writer.vec3(collider.verts[0])
+                        writer.f32(collider.radius)
+
+def save(operator, context, settings, filepath="", mdl_version=800):
+    scene = context.scene
+    current_frame = scene.frame_current
+    scene.frame_set(0)
+
+    model = War3Model(context)
+    model.from_scene(context, settings, operator.report)
+
+    scene.frame_set(current_frame)
+
+    writer = MDXWriter()
+    _write_model(writer, model, mdl_version)
+    writer.save(filepath)

--- a/export_mdl/import_mdx.py
+++ b/export_mdl/import_mdx.py
@@ -1,0 +1,705 @@
+import os.path
+import struct
+
+from .classes.War3AnimationCurve import War3AnimationCurve
+from .classes.War3AnimationSequence import War3AnimationSequence
+from .classes.War3Bone import War3Bone
+from .classes.War3CollisionShape import War3CollisionShape
+from .classes.War3EventObject import War3EventObject
+from .classes.War3Geoset import War3Geoset
+from .classes.War3GeosetAnim import War3GeosetAnim
+from .classes.War3Light import War3Light
+from .classes.War3Material import War3Material
+from .classes.War3MaterialLayer import War3MaterialLayer
+from .classes.War3Model import War3Model
+from .classes.War3Object import War3Object
+from .classes.War3ParticleSystem import War3ParticleSystem
+from .classes.War3Texture import War3Texture
+from .classes.War3TextureAnim import War3TextureAnim
+
+
+FILTER_MODES = {
+    0: "None",
+    1: "Transparent",
+    2: "Blend",
+    3: "Additive",
+    4: "AddAlpha",
+    5: "Modulate",
+    6: "Modulate2x",
+}
+
+INTERPOLATIONS = {
+    0: "DontInterp",
+    1: "Linear",
+    2: "Hermite",
+    3: "Bezier",
+}
+
+LIGHT_TYPES = {
+    0: "Omnidirectional",
+    1: "Directional",
+    2: "Ambient",
+}
+
+
+class MDXReader:
+    def __init__(self, path):
+        with open(path, "rb") as file:
+            self.data = file.read()
+        self.offset = 0
+
+    def tell(self):
+        return self.offset
+
+    def seek(self, offset):
+        self.offset = offset
+
+    def skip(self, size):
+        self.offset += size
+
+    def read(self, size):
+        value = self.data[self.offset:self.offset + size]
+        self.offset += size
+        return value
+
+    def tag(self):
+        return self.read(4).decode("ascii", errors="replace")
+
+    def u8(self):
+        return self.unpack("<B")
+
+    def u16(self):
+        return self.unpack("<H")
+
+    def u32(self):
+        return self.unpack("<I")
+
+    def i32(self):
+        return self.unpack("<i")
+
+    def f32(self):
+        return self.unpack("<f")
+
+    def vec2(self):
+        return self.unpack("<2f")
+
+    def vec3(self):
+        return self.unpack("<3f")
+
+    def vec4(self):
+        return self.unpack("<4f")
+
+    def unpack(self, fmt):
+        size = struct.calcsize(fmt)
+        values = struct.unpack_from(fmt, self.data, self.offset)
+        self.offset += size
+        return values[0] if len(values) == 1 else values
+
+    def fixed_string(self, size):
+        value = self.read(size).split(b"\0", 1)[0]
+        return value.decode("utf-8", errors="replace")
+
+
+def _read_extent(reader):
+    reader.f32()
+    minimum = reader.vec3()
+    maximum = reader.vec3()
+    return minimum, maximum
+
+
+def _read_sized_end(reader):
+    size_offset = reader.tell()
+    size = reader.u32()
+    return size_offset + size
+
+
+def _color_rgb(value):
+    return tuple(reversed(value[:3]))
+
+
+def _rotation_wxyz(value):
+    return (value[3], value[0], value[1], value[2])
+
+
+def _read_track(reader, tag, model):
+    curve = War3AnimationCurve()
+    frame_count = reader.u32()
+    curve.interpolation = INTERPOLATIONS.get(reader.u32(), "Linear")
+    global_sequence_id = reader.i32()
+    curve.global_sequence = list(model.global_seqs)[global_sequence_id] if global_sequence_id >= 0 and global_sequence_id < len(model.global_seqs) else -1
+    dimensions = {
+        "KGTR": 3, "KGRT": 4, "KGSC": 3,
+        "KGAO": 1, "KGAC": 3, "KMTA": 1,
+        "KTAT": 3, "KTAR": 4, "KTAS": 3,
+        "KLAS": 1, "KLAE": 1, "KLAC": 3, "KLAI": 1, "KLBI": 1, "KLBC": 3, "KLAV": 1,
+        "KATV": 1, "KPEE": 1, "KPEG": 1, "KPLN": 1, "KPLT": 1, "KPEV": 1, "KPEL": 1, "KPES": 1,
+        "KP2S": 1, "KP2R": 1, "KP2L": 1, "KP2G": 1, "KP2V": 1, "KP2E": 1, "KP2W": 1, "KP2N": 1,
+        "KRHA": 1, "KRHB": 1, "KRAL": 1, "KRCO": 3, "KRVS": 1,
+    }.get(tag, 1)
+
+    for _ in range(frame_count):
+        frame = reader.u32()
+        value = _read_track_value(reader, dimensions)
+        if tag in {"KGRT", "KTAR"}:
+            value = _rotation_wxyz(value)
+        elif tag in {"KGAC", "KLAC", "KLBC", "KRCO"}:
+            value = _color_rgb(value)
+        curve.keyframes[frame] = value
+        if curve.interpolation in {"Hermite", "Bezier"}:
+            curve.handles_left[frame] = _read_track_value(reader, dimensions)
+            curve.handles_right[frame] = _read_track_value(reader, dimensions)
+    return curve
+
+
+def _read_track_value(reader, dimensions):
+    if dimensions == 1:
+        return (reader.f32(),)
+    if dimensions == 2:
+        return reader.vec2()
+    if dimensions == 3:
+        return reader.vec3()
+    if dimensions == 4:
+        return reader.vec4()
+    return ()
+
+
+def _read_node_tracks(reader, end, node, model):
+    while reader.tell() < end:
+        if reader.tell() + 4 > end:
+            break
+        tag_offset = reader.tell()
+        tag = reader.tag()
+        if tag == "KGTR":
+            node.anim_loc = _read_track(reader, tag, model)
+        elif tag == "KGRT":
+            node.anim_rot = _read_track(reader, tag, model)
+        elif tag == "KGSC":
+            node.anim_scale = _read_track(reader, tag, model)
+        else:
+            reader.seek(tag_offset)
+            break
+
+
+def _skip_track(reader):
+    frame_count = reader.u32()
+    interpolation = reader.u32()
+    reader.i32()
+    value_size = 4
+    if interpolation in {2, 3}:
+        value_size *= 3
+    reader.skip(frame_count * (4 + value_size))
+
+
+def _read_node(reader, model, node):
+    node.name = reader.fixed_string(80)
+    node.object_id = reader.u32()
+    parent_id = reader.i32()
+    node.parent_id = None if parent_id < 0 else parent_id
+    flags = reader.u32()
+    node.billboarded = bool(flags & 0x8)
+    node.billboard_lock = (bool(flags & 0x10), bool(flags & 0x20), bool(flags & 0x40))
+    return node
+
+
+def _read_mdx(model, reader):
+    if reader.tag() != "MDLX":
+        raise ValueError("Not a Warcraft MDX file")
+
+    while reader.tell() < len(reader.data):
+        tag = reader.tag()
+        size = reader.u32()
+        end = reader.tell() + size
+        if tag == "MODL":
+            model.name = reader.fixed_string(80)
+            reader.fixed_string(260)
+            model.global_extents_min, model.global_extents_max = _read_extent(reader)
+            reader.u32()
+        elif tag == "SEQS":
+            _read_sequences(model, reader, end)
+        elif tag == "GLBS":
+            while reader.tell() < end:
+                model.global_seqs.add(reader.u32())
+        elif tag == "TEXS":
+            _read_textures(model, reader, end)
+        elif tag == "MTLS":
+            _read_materials(model, reader, end)
+        elif tag == "TXAN":
+            _read_texture_anims(model, reader, end)
+        elif tag == "GEOS":
+            _read_geosets(model, reader, end)
+        elif tag == "GEOA":
+            _read_geoset_anims(model, reader, end)
+        elif tag == "BONE":
+            _read_bones(model, reader, end)
+        elif tag == "HELP":
+            _read_helpers(model, reader, end)
+        elif tag == "LITE":
+            _read_lights(model, reader, end)
+        elif tag == "ATCH":
+            _read_attachments(model, reader, end)
+        elif tag == "PIVT":
+            model.pivots = []
+            while reader.tell() < end:
+                model.pivots.append(reader.vec3())
+        elif tag == "PREM":
+            _read_particle_emitters(model, reader, end)
+        elif tag == "PRE2":
+            _read_particle_emitters2(model, reader, end)
+        elif tag == "RIBB":
+            _read_ribbon_emitters(model, reader, end)
+        elif tag == "EVTS":
+            _read_event_objects(model, reader, end)
+        elif tag == "CLID":
+            _read_collision_shapes(model, reader, end)
+        reader.seek(end)
+
+    _finalize_model(model)
+
+
+def _read_sequences(model, reader, end):
+    while reader.tell() < end:
+        name = reader.fixed_string(80)
+        start = reader.u32()
+        finish = reader.u32()
+        movement_speed = reader.f32()
+        flags = reader.u32()
+        rarity = reader.f32()
+        reader.u32()
+        _read_extent(reader)
+        sequence = War3AnimationSequence(name, start, finish, bool(flags & 1), movement_speed)
+        sequence.rarity = rarity
+        model.sequences.append(sequence)
+
+
+def _read_textures(model, reader, end):
+    while reader.tell() < end:
+        replaceable_id = reader.u32()
+        image_path = reader.fixed_string(260)
+        reader.u32()
+        texture = War3Texture(image_path)
+        texture.replaceable_id = replaceable_id
+        texture.is_replaceable = replaceable_id != 0
+        if texture.is_replaceable:
+            texture.image_path = None
+        model.textures.append(texture)
+
+
+def _read_materials(model, reader, end):
+    material_index = 0
+    while reader.tell() < end:
+        material_end = _read_sized_end(reader)
+        material = War3Material("Material %d" % material_index)
+        material.priority_plane = reader.u32()
+        material_flags = reader.u32()
+        material.use_const_color = bool(material_flags & 0x1)
+        if reader.tell() < material_end and reader.tag() == "LAYS":
+            layer_count = reader.u32()
+            for _ in range(layer_count):
+                layer_end = _read_sized_end(reader)
+                layer = War3MaterialLayer()
+                layer.filter_mode = FILTER_MODES.get(reader.u32(), "None")
+                flags = reader.u32()
+                layer.unshaded = bool(flags & 0x1)
+                layer.two_sided = bool(flags & 0x10)
+                layer.unfogged = bool(flags & 0x20)
+                layer.no_depth_test = bool(flags & 0x40)
+                layer.no_depth_set = bool(flags & 0x80)
+                layer.texture_id = reader.u32()
+                texture_anim_id = reader.i32()
+                layer.texture_anim_id = None if texture_anim_id < 0 else texture_anim_id
+                reader.u32()
+                layer.alpha_value = reader.f32()
+                while reader.tell() < layer_end:
+                    tag_offset = reader.tell()
+                    tag = reader.tag()
+                    if tag == "KMTA":
+                        layer.alpha_anim = _read_track(reader, tag, model)
+                    else:
+                        reader.seek(tag_offset)
+                        break
+                material.layers.append(layer)
+                reader.seek(layer_end)
+        model.materials.append(material)
+        material_index += 1
+        reader.seek(material_end)
+
+
+def _read_texture_anims(model, reader, end):
+    while reader.tell() < end:
+        anim_end = _read_sized_end(reader)
+        anim = War3TextureAnim()
+        while reader.tell() < anim_end:
+            tag_offset = reader.tell()
+            tag = reader.tag()
+            if tag == "KTAT":
+                anim.translation = _read_track(reader, tag, model)
+            elif tag == "KTAR":
+                anim.rotation = _read_track(reader, tag, model)
+            elif tag == "KTAS":
+                anim.scale = _read_track(reader, tag, model)
+            else:
+                reader.seek(tag_offset)
+                break
+        model.tvertex_anims.append(anim)
+        reader.seek(anim_end)
+
+
+def _read_geosets(model, reader, end):
+    while reader.tell() < end:
+        geoset_end = _read_sized_end(reader)
+        geoset = War3Geoset()
+        positions = []
+        normals = []
+        uvs = []
+        vertex_groups = []
+        counts = []
+        while reader.tell() < geoset_end:
+            tag = reader.tag()
+            if tag == "VRTX":
+                positions = [reader.vec3() for _ in range(reader.u32())]
+            elif tag == "NRMS":
+                normals = [reader.vec3() for _ in range(reader.u32())]
+            elif tag == "PTYP":
+                reader.skip(reader.u32() * 4)
+            elif tag == "PCNT":
+                reader.skip(reader.u32() * 4)
+            elif tag == "PVTX":
+                geoset.triangles = [reader.u16() for _ in range(reader.u32())]
+            elif tag == "GNDX":
+                vertex_groups = [reader.u8() for _ in range(reader.u32())]
+            elif tag == "MTGC":
+                counts = [reader.u32() for _ in range(reader.u32())]
+            elif tag == "MATS":
+                matrix_values = [reader.u32() for _ in range(reader.u32())]
+                geoset.matrices = []
+                offset = 0
+                for count in counts:
+                    geoset.matrices.append(tuple(matrix_values[offset:offset + count]))
+                    offset += count
+            elif tag == "UVAS":
+                reader.u32()
+            elif tag == "UVBS":
+                uvs = [reader.vec2() for _ in range(reader.u32())]
+            else:
+                break
+            if reader.tell() + 4 <= geoset_end:
+                next_tag = reader.data[reader.tell():reader.tell() + 4]
+                if next_tag not in {b"VRTX", b"NRMS", b"PTYP", b"PCNT", b"PVTX", b"GNDX", b"MTGC", b"MATS", b"UVAS", b"UVBS"}:
+                    break
+
+        if reader.tell() + 28 <= geoset_end:
+            geoset.material_id = reader.u32()
+            reader.u32()
+            geoset.min_extent, geoset.max_extent = _read_extent(reader)
+        if reader.tell() + 4 <= geoset_end:
+            extent_count = reader.u32()
+            for _ in range(extent_count):
+                if reader.tell() + 28 > geoset_end:
+                    break
+                _read_extent(reader)
+
+        while reader.tell() + 8 <= geoset_end:
+            tag = reader.tag()
+            if tag == "UVAS":
+                reader.u32()
+            elif tag == "UVBS":
+                uvs = [reader.vec2() for _ in range(reader.u32())]
+            else:
+                break
+        geoset.vertices = [
+            (
+                positions[i],
+                normals[i] if i < len(normals) else (0, 0, 1),
+                uvs[i] if i < len(uvs) else (0, 0),
+                vertex_groups[i] if i < len(vertex_groups) else 0,
+            )
+            for i in range(len(positions))
+        ]
+        model.geosets.append(geoset)
+        reader.seek(geoset_end)
+
+
+def _read_geoset_anims(model, reader, end):
+    while reader.tell() < end:
+        anim_end = _read_sized_end(reader)
+        alpha = reader.f32()
+        reader.u32()
+        color = _color_rgb(reader.vec3())
+        geoset_id = reader.u32()
+        anim = War3GeosetAnim(color, None, None)
+        anim.geoset_id = geoset_id
+        while reader.tell() < anim_end:
+            tag_offset = reader.tell()
+            tag = reader.tag()
+            if tag == "KGAO":
+                anim.alpha_anim = _read_track(reader, tag, model)
+            elif tag == "KGAC":
+                anim.color_anim = _read_track(reader, tag, model)
+            else:
+                reader.seek(tag_offset)
+                break
+        if 0 <= geoset_id < len(model.geosets):
+            anim.geoset = model.geosets[geoset_id]
+        if alpha < 1 and anim.alpha_anim is None:
+            static_alpha = War3AnimationCurve()
+            static_alpha.keyframes[0] = (alpha,)
+            anim.alpha_anim = static_alpha
+        model.geoset_anims.append(anim)
+        reader.seek(anim_end)
+
+
+def _read_bones(model, reader, end):
+    while reader.tell() < end:
+        bone_node_end = _read_sized_end(reader)
+        bone = _read_node(reader, model, War3Bone(""))
+        _read_node_tracks(reader, bone_node_end, bone, model)
+        reader.seek(bone_node_end)
+        bone.geoset_id = reader.i32() if reader.tell() + 4 <= end else -1
+        geoset_anim_id = reader.i32() if reader.tell() + 4 <= end else -1
+        bone.geoset_anim_id = None if geoset_anim_id < 0 else geoset_anim_id
+        model.objects["bone"].add(bone)
+
+
+def _read_helpers(model, reader, end):
+    while reader.tell() < end:
+        helper_end = _read_sized_end(reader)
+        helper = _read_node(reader, model, War3Object(""))
+        _read_node_tracks(reader, helper_end, helper, model)
+        model.objects["helper"].add(helper)
+        reader.seek(helper_end)
+
+
+def _read_lights(model, reader, end):
+    while reader.tell() < end:
+        light_end = _read_sized_end(reader)
+        light = _read_node(reader, model, War3Light(""))
+        light.type = LIGHT_TYPES.get(reader.u32(), "Omnidirectional")
+        light.atten_start = reader.f32()
+        light.atten_end = reader.f32()
+        light.color = _color_rgb(reader.vec3())
+        light.intensity = reader.f32()
+        light.amb_color = _color_rgb(reader.vec3())
+        light.amb_intensity = reader.f32()
+        while reader.tell() < light_end:
+            tag_offset = reader.tell()
+            tag = reader.tag()
+            if tag == "KLAS":
+                light.atten_start_anim = _read_track(reader, tag, model)
+            elif tag == "KLAE":
+                light.atten_end_anim = _read_track(reader, tag, model)
+            elif tag == "KLAC":
+                light.color_anim = _read_track(reader, tag, model)
+            elif tag == "KLAI":
+                light.intensity_anim = _read_track(reader, tag, model)
+            elif tag == "KLBI":
+                light.amb_intensity_anim = _read_track(reader, tag, model)
+            elif tag == "KLBC":
+                light.amb_color_anim = _read_track(reader, tag, model)
+            elif tag == "KLAV":
+                light.visibility = _read_track(reader, tag, model)
+            else:
+                reader.seek(tag_offset)
+                break
+        model.objects["light"].add(light)
+        reader.seek(light_end)
+
+
+def _read_attachments(model, reader, end):
+    while reader.tell() < end:
+        attachment_end = _read_sized_end(reader)
+        attachment = _read_node(reader, model, War3Object(""))
+        attachment.path = reader.fixed_string(260)
+        attachment.attachment_id = reader.u32()
+        while reader.tell() < attachment_end:
+            tag_offset = reader.tell()
+            tag = reader.tag()
+            if tag == "KATV":
+                attachment.visibility = _read_track(reader, tag, model)
+            else:
+                reader.seek(tag_offset)
+                break
+        model.objects["attachment"].add(attachment)
+        reader.seek(attachment_end)
+
+
+def _read_particle_emitters(model, reader, end):
+    while reader.tell() < end:
+        emitter_end = _read_sized_end(reader)
+        emitter = _read_node(reader, model, War3ParticleSystem(""))
+        emitter.emitter_type = "ParticleEmitter"
+        emitter.emission_rate = reader.f32()
+        emitter.gravity = reader.f32()
+        emitter.longitude = reader.f32()
+        emitter.latitude = reader.f32()
+        emitter.model_path = reader.fixed_string(260)
+        emitter.life_span = reader.f32()
+        emitter.speed = reader.f32()
+        model.objects["particle"].add(emitter)
+        reader.seek(emitter_end)
+
+
+def _read_particle_emitters2(model, reader, end):
+    while reader.tell() < end:
+        emitter_end = _read_sized_end(reader)
+        emitter = _read_node(reader, model, War3ParticleSystem(""))
+        emitter.emitter_type = "ParticleEmitter2"
+        emitter.speed = reader.f32()
+        emitter.variation = reader.f32()
+        emitter.latitude = reader.f32()
+        emitter.gravity = reader.f32()
+        emitter.life_span = reader.f32()
+        emitter.emission_rate = reader.f32()
+        emitter.width = reader.f32()
+        emitter.height = reader.f32()
+        emitter.filter_mode = FILTER_MODES.get(reader.u32(), "Blend")
+        emitter.rows = reader.u32()
+        emitter.cols = reader.u32()
+        head_tail = reader.u32()
+        emitter.head = head_tail in {0, 2}
+        emitter.tail = head_tail in {1, 2}
+        emitter.tail_length = reader.f32()
+        emitter.time = reader.f32()
+        emitter.start_color = _color_rgb(reader.vec3())
+        emitter.mid_color = _color_rgb(reader.vec3())
+        emitter.end_color = _color_rgb(reader.vec3())
+        emitter.start_alpha = reader.u8()
+        emitter.mid_alpha = reader.u8()
+        emitter.end_alpha = reader.u8()
+        reader.u8()
+        scales = reader.vec3()
+        emitter.start_scale, emitter.mid_scale, emitter.end_scale = scales
+        emitter.head_life_start, emitter.head_life_end, emitter.head_life_repeat = reader.u32(), reader.u32(), reader.u32()
+        emitter.head_decay_start, emitter.head_decay_end, emitter.head_decay_repeat = reader.u32(), reader.u32(), reader.u32()
+        emitter.tail_life_start, emitter.tail_life_end, emitter.tail_life_repeat = reader.u32(), reader.u32(), reader.u32()
+        emitter.tail_decay_start, emitter.tail_decay_end, emitter.tail_decay_repeat = reader.u32(), reader.u32(), reader.u32()
+        emitter.texture_id = reader.u32()
+        emitter.priority_plane = reader.u32()
+        flags = reader.u32()
+        emitter.sort_far_z = bool(flags & 0x10000)
+        emitter.unshaded = bool(flags & 0x8000)
+        emitter.line_emitter = bool(flags & 0x20000)
+        emitter.unfogged = bool(flags & 0x40000)
+        emitter.model_space = bool(flags & 0x80000)
+        emitter.xy_quad = bool(flags & 0x100000)
+        model.objects["particle2"].add(emitter)
+        reader.seek(emitter_end)
+
+
+def _read_ribbon_emitters(model, reader, end):
+    while reader.tell() < end:
+        emitter_end = _read_sized_end(reader)
+        emitter = _read_node(reader, model, War3ParticleSystem(""))
+        emitter.emitter_type = "RibbonEmitter"
+        height_above = reader.f32()
+        height_below = reader.f32()
+        emitter.dimensions = (height_above + height_below, height_above + height_below, 0)
+        emitter.alpha = reader.f32()
+        emitter.ribbon_color = _color_rgb(reader.vec3())
+        emitter.life_span = reader.f32()
+        emitter.texture_id = reader.u32()
+        material_id = reader.u32()
+        emitter.ribbon_material = model.materials[material_id] if material_id < len(model.materials) else 0
+        emitter.rows = reader.u32()
+        emitter.cols = reader.u32()
+        emitter.emission_rate = reader.f32()
+        emitter.gravity = reader.f32()
+        model.objects["ribbon"].add(emitter)
+        reader.seek(emitter_end)
+
+
+def _read_event_objects(model, reader, end):
+    while reader.tell() < end:
+        event_end = _read_sized_end(reader)
+        event = _read_node(reader, model, War3EventObject(""))
+        while reader.tell() < event_end:
+            tag_offset = reader.tell()
+            tag = reader.tag()
+            if tag == "KEVT":
+                event.track = _read_track(reader, tag, model)
+            else:
+                reader.seek(tag_offset)
+                break
+        model.objects["eventobject"].add(event)
+        reader.seek(event_end)
+
+
+def _read_collision_shapes(model, reader, end):
+    while reader.tell() < end:
+        node_end = _read_sized_end(reader)
+        collider = _read_node(reader, model, War3CollisionShape(""))
+        _read_node_tracks(reader, node_end, collider, model)
+        reader.seek(node_end)
+        if reader.tell() + 4 > end:
+            break
+        shape_type = reader.u32()
+        collider.type = "Box" if shape_type == 0 else "Sphere"
+        if collider.type == "Box":
+            collider.vertices = []
+            if reader.tell() + 24 <= end:
+                collider.vertices = [reader.vec3(), reader.vec3()]
+        else:
+            if reader.tell() + 12 <= end:
+                collider.vertices = [reader.vec3()]
+            if reader.tell() + 4 <= end:
+                collider.radius = reader.f32()
+        model.objects["collisionshape"].add(collider)
+
+
+def _finalize_model(model):
+    if not model.materials:
+        material = War3Material("Material 0")
+        material.layers.append(War3MaterialLayer())
+        model.materials.append(material)
+    if not model.textures:
+        model.textures.append(War3Texture(War3Model.default_texture))
+
+    for index, geoset in enumerate(model.geosets):
+        if not geoset.matrices:
+            geoset.matrices = [(0,)]
+        if geoset.min_extent is None:
+            points = [vertex[0] for vertex in geoset.vertices]
+            geoset.min_extent = tuple(min(point[i] for point in points) for i in range(3)) if points else (0, 0, 0)
+            geoset.max_extent = tuple(max(point[i] for point in points) for i in range(3)) if points else (0, 0, 0)
+        if geoset.material_id >= len(model.materials):
+            geoset.material_id = 0
+        geoset.mat_name = model.materials[geoset.material_id].name
+
+    if not model.objects["bone"] and model.geosets:
+        bone = War3Bone("Bone_Root")
+        bone.object_id = 0
+        bone.parent_id = None
+        bone.geoset_id = -1
+        bone.geoset_anim_id = None
+        model.objects["bone"].add(bone)
+
+    model.objects_all = sorted(
+        list(model.objects["bone"])
+        + list(model.objects["helper"])
+        + list(model.objects["light"])
+        + list(model.objects["attachment"])
+        + list(model.objects["particle"])
+        + list(model.objects["particle2"])
+        + list(model.objects["ribbon"])
+        + list(model.objects["eventobject"])
+        + list(model.objects["collisionshape"]),
+        key=lambda node: node.object_id,
+    )
+    model.objects["bone"] = set(sorted(model.objects["bone"], key=lambda node: node.object_id))
+    model.objects["helper"] = set(sorted(model.objects["helper"], key=lambda node: node.object_id))
+    model.object_indices = {node.name: node.object_id for node in model.objects_all}
+
+    if not hasattr(model, "pivots") or not model.pivots:
+        max_id = max([node.object_id for node in model.objects_all], default=0)
+        model.pivots = [(0, 0, 0)] * (max_id + 1)
+    for node in model.objects_all:
+        if node.object_id < len(model.pivots):
+            node.pivot = model.pivots[node.object_id]
+
+
+def load(operator, context, settings, filepath=""):
+    print("Beginning MDX load of model %s" % filepath)
+    model = War3Model(context)
+    reader = MDXReader(filepath)
+    _read_mdx(model, reader)
+    print("Converting MDX to scene...")
+    model.to_scene(context, settings.global_matrix, os.path.dirname(filepath))

--- a/export_mdl/operators/WAR3_OT_export_mdl.py
+++ b/export_mdl/operators/WAR3_OT_export_mdl.py
@@ -15,14 +15,14 @@ from ..classes.War3ExportSettings import War3ExportSettings
 
 @orientation_helper(axis_forward='-X', axis_up='Z')
 class WAR3_OT_export_mdl(Operator, ExportHelper):
-    """MDL Exporter"""
+    """MDL/MDX Exporter"""
     bl_idname = 'export.mdl_exporter'
-    bl_description = 'Warctaft 3 MDL Exporter'
-    bl_label = 'Export .MDL'
+    bl_description = 'Warcraft 3 MDL/MDX Exporter'
+    bl_label = 'Export .MDL/.MDX'
     filename_ext = ".mdl"
     
     filter_glob : StringProperty(
-            default="*.mdl", options={'HIDDEN'}
+            default="*.mdl;*.mdx", options={'HIDDEN'}
             )
     
     filepath : StringProperty(
@@ -58,7 +58,8 @@ class WAR3_OT_export_mdl(Operator, ExportHelper):
     
     def execute(self, context):                                   
         filepath = self.filepath
-        filepath = bpy.path.ensure_ext(filepath, self.filename_ext)
+        if not filepath.lower().endswith((".mdl", ".mdx")):
+            filepath = bpy.path.ensure_ext(filepath, self.filename_ext)
         
         settings = War3ExportSettings()
         settings.global_matrix = axis_conversion(to_forward=self.axis_forward,
@@ -69,8 +70,12 @@ class WAR3_OT_export_mdl(Operator, ExportHelper):
         settings.optimize_animation = self.optimize_animation
         settings.optimize_tolerance = self.optimize_tolerance
         
-        from .. import export_mdl
-        export_mdl.save(self, context, settings, filepath=filepath, mdl_version=800)
+        if filepath.lower().endswith(".mdx"):
+            from .. import export_mdx
+            export_mdx.save(self, context, settings, filepath=filepath, mdl_version=800)
+        else:
+            from .. import export_mdl
+            export_mdl.save(self, context, settings, filepath=filepath, mdl_version=800)
         
         return {'FINISHED'}
        

--- a/export_mdl/operators/WAR3_OT_import_mdl.py
+++ b/export_mdl/operators/WAR3_OT_import_mdl.py
@@ -8,14 +8,14 @@ from mathutils import Matrix
 from ..classes.War3ImportSettings import War3ImportSettings 
 
 class WAR3_OT_import_mdl(Operator, ImportHelper):
-    """MDL Importer"""
+    """MDL/MDX Importer"""
     bl_idname = 'import.mdl_importer'
-    bl_description = 'Warcraft 3 MDL Importer'
-    bl_label = 'Import .MDL'
+    bl_description = 'Warcraft 3 MDL/MDX Importer'
+    bl_label = 'Import .MDL/.MDX'
     filename_ext = '.mdl'
 
     filter_glob : StringProperty(
-        default="*.mdl", options={'HIDDEN'}
+        default="*.mdl;*.mdx", options={'HIDDEN'}
         )
     
     filepath : StringProperty(
@@ -32,7 +32,10 @@ class WAR3_OT_import_mdl(Operator, ImportHelper):
 
     def execute(self, context):
         filepath = self.filepath
-        filepath = bpy.path.ensure_ext(filepath, self.filename_ext)
+        lower_filepath = filepath.lower()
+        if not lower_filepath.endswith(".mdl"):
+            if not lower_filepath.endswith(".mdx"):
+                filepath = bpy.path.ensure_ext(filepath, self.filename_ext)
 
         settings = War3ImportSettings()
         settings.global_matrix = Matrix.Scale(self.global_scale, 4)
@@ -40,8 +43,12 @@ class WAR3_OT_import_mdl(Operator, ImportHelper):
                                  to_up='Z',
                                  ).to_4x4().inverted() @ Matrix.Scale(self.global_scale, 4)
 
-        from .. import import_mdl
-        import_mdl.load(self, context, settings, filepath=filepath)
+        if filepath.lower().endswith(".mdx"):
+            from .. import import_mdx
+            import_mdx.load(self, context, settings, filepath=filepath)
+        else:
+            from .. import import_mdl
+            import_mdl.load(self, context, settings, filepath=filepath)
 
         return {'FINISHED'}
 

--- a/export_mdl/ui/WAR3_MT_add_object.py
+++ b/export_mdl/ui/WAR3_MT_add_object.py
@@ -7,7 +7,7 @@ from ..operators.WAR3_OT_add_anim_sequence import WAR3_OT_add_anim_sequence
 class WAR3_MT_add_object(Menu):
     bl_idname = "WAR3_MT_add_object"
     bl_label = "Add MDL object"
-    bl_options = {'REGISTER', 'UNDO'}
+    bl_options = {'SEARCH_ON_KEY_PRESS'}
 
     def draw(self, context):
         layout = self.layout

--- a/export_mdl/ui/WAR3_PT_billboard_panel.py
+++ b/export_mdl/ui/WAR3_PT_billboard_panel.py
@@ -30,7 +30,7 @@ class WAR3_PT_billboard_panel(Panel):
         if obj.type == 'EMPTY' and obj.name.lower().startswith("bone"):
             return True
             
-        if obj.type in ('LAMP', 'LIGHT'):
+        if obj.type == 'LIGHT':
             return True
             
         if obj.name.endswith(" Ref"):

--- a/tools/test_mdx_import.py
+++ b/tools/test_mdx_import.py
@@ -1,0 +1,69 @@
+import json
+import sys
+import traceback
+from pathlib import Path
+
+import bpy
+
+REPO = Path(r"D:\code2\mdl-exporter")
+MODEL_DIR = Path(r"C:\Users\admin\Desktop\模型")
+
+sys.path.insert(0, str(REPO))
+
+import export_mdl
+from export_mdl.classes.War3ImportSettings import War3ImportSettings
+from export_mdl import import_mdx
+
+
+def clear_scene():
+    if bpy.ops.object.mode_set.poll():
+        bpy.ops.object.mode_set(mode="OBJECT")
+    for obj in list(bpy.context.scene.objects):
+        bpy.data.objects.remove(obj, do_unlink=True)
+    for collection in (
+        bpy.data.meshes,
+        bpy.data.materials,
+        bpy.data.images,
+        bpy.data.armatures,
+        bpy.data.lights,
+        bpy.data.cameras,
+    ):
+        for item in list(collection):
+            if item.users == 0:
+                collection.remove(item)
+
+
+class Reporter:
+    def report(self, kind, message):
+        print("REPORT", kind, message)
+
+
+def main():
+    settings = War3ImportSettings()
+    settings.global_matrix = bpy.mathutils.Matrix.Identity(4) if hasattr(bpy, "mathutils") else None
+    from mathutils import Matrix
+
+    settings.global_matrix = Matrix.Identity(4)
+    export_mdl.register()
+    results = []
+    for path in sorted(MODEL_DIR.glob("*.mdx")):
+        clear_scene()
+        try:
+            import_mdx.load(Reporter(), bpy.context, settings, filepath=str(path))
+            mesh_count = len([obj for obj in bpy.context.scene.objects if obj.type == "MESH"])
+            object_count = len(bpy.context.scene.objects)
+            results.append({"file": path.name, "ok": True, "objects": object_count, "meshes": mesh_count})
+        except Exception as exc:
+            results.append({
+                "file": path.name,
+                "ok": False,
+                "error": repr(exc),
+                "traceback": traceback.format_exc(limit=8),
+            })
+    print("MDX_IMPORT_RESULTS_START")
+    print(json.dumps(results, ensure_ascii=False, indent=2))
+    print("MDX_IMPORT_RESULTS_END")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/test_mdx_parse.py
+++ b/tools/test_mdx_parse.py
@@ -1,0 +1,45 @@
+import json
+import sys
+import traceback
+from pathlib import Path
+
+import bpy
+
+REPO = Path(r"D:\code2\mdl-exporter")
+MODEL_DIR = Path(r"C:\Users\admin\Desktop\模型")
+
+sys.path.insert(0, str(REPO))
+
+from export_mdl.classes.War3Model import War3Model
+from export_mdl.import_mdx import MDXReader, _read_mdx
+
+
+def main():
+    results = []
+    for path in sorted(MODEL_DIR.glob("*.mdx")):
+        try:
+            model = War3Model(bpy.context)
+            _read_mdx(model, MDXReader(str(path)))
+            results.append({
+                "file": path.name,
+                "ok": True,
+                "geosets": len(model.geosets),
+                "materials": len(model.materials),
+                "textures": len(model.textures),
+                "bones": len(model.objects["bone"]),
+                "pivots": len(getattr(model, "pivots", [])),
+            })
+        except Exception as exc:
+            results.append({
+                "file": path.name,
+                "ok": False,
+                "error": repr(exc),
+                "traceback": traceback.format_exc(limit=10),
+            })
+    print("MDX_PARSE_RESULTS_START")
+    print(json.dumps(results, ensure_ascii=False, indent=2))
+    print("MDX_PARSE_RESULTS_END")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/test_one_mdx_import.py
+++ b/tools/test_one_mdx_import.py
@@ -1,0 +1,28 @@
+import sys
+from pathlib import Path
+
+import bpy
+from mathutils import Matrix
+
+REPO = Path(r"D:\code2\mdl-exporter")
+FILE = Path(r"C:\Users\admin\Desktop\模型\55993a708d1557cd618bfeb40e6edd32.mdx")
+
+sys.path.insert(0, str(REPO))
+
+import export_mdl
+from export_mdl.classes.War3ImportSettings import War3ImportSettings
+from export_mdl import import_mdx
+
+
+class Reporter:
+    def report(self, kind, message):
+        print("REPORT", kind, message, flush=True)
+
+
+settings = War3ImportSettings()
+settings.global_matrix = Matrix.Identity(4)
+export_mdl.register()
+print("IMPORT_START", FILE, flush=True)
+import_mdx.load(Reporter(), bpy.context, settings, filepath=str(FILE))
+meshes = [obj.name for obj in bpy.context.scene.objects if obj.type == "MESH"]
+print("IMPORT_DONE", len(bpy.context.scene.objects), len(meshes), meshes[:10], flush=True)

--- a/tools/test_one_mdx_parse.py
+++ b/tools/test_one_mdx_parse.py
@@ -1,0 +1,17 @@
+import sys
+from pathlib import Path
+
+import bpy
+
+REPO = Path(r"D:\code2\mdl-exporter")
+FILE = Path(r"C:\Users\admin\Desktop\模型\55993a708d1557cd618bfeb40e6edd32.mdx")
+
+sys.path.insert(0, str(REPO))
+
+from export_mdl.classes.War3Model import War3Model
+from export_mdl.import_mdx import MDXReader, _read_mdx
+
+print("START", FILE, flush=True)
+model = War3Model(bpy.context)
+_read_mdx(model, MDXReader(str(FILE)))
+print("DONE", len(model.geosets), len(model.materials), len(model.objects["bone"]), flush=True)


### PR DESCRIPTION
## Summary

This PR updates the add-on for modern Blender compatibility and expands Warcraft model format support.

- Update registration, menus, mesh/material access, lights, animation curve lookup, normals, UV handling, and node lookup for Blender 4.x/5.x APIs
- Add MDX import/export support alongside the existing MDL workflow
- Add BLP texture loading support for BLP1/BLP2, including palette, JPEG, DXT1, DXT3, DXT5, and BGRA cases
- Fix several import/export issues found while testing MDX round trips

## Testing

- Add-on registration tested in Blender 5.1.1
- Simple MDL import and export tested
- Real model import tested with 50 bones and 2873 vertices
- Import/export round trip tested with a 59884-line MDL output
- BLP1 JPEG texture loading and color channel handling tested